### PR TITLE
add react-router-dom version - this fixes 'npm install' error

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"react": "^15.4.2",
 		"react-dom": "^15.4.2",
 		"react-redux": "^5.0.3",
-		"react-router-dom": "next",
+		"react-router-dom": "^4.1.2",
 		"react-router-redux": "^4.0.8",
 		"redux": "^3.6.0",
 		"redux-actions": "^1.2.2",


### PR DESCRIPTION
This fixes the failure to install the packages with `npm install` - now with this command the packages are installed successfully.